### PR TITLE
upgrade typography: Fraunces display + JetBrains Mono code

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>FOKS - Federated Open Key Service</title>
     <link href="/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700;9..144,800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
       :root {
         --foks-dark: #1b1f2e;
@@ -13,16 +16,27 @@
         --foks-muted: #6c7a89;
         --foks-alt-bg: #f5f7fa;
         --foks-border: #e0e4ea;
+
+        --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+        --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
       }
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-family: var(--font-body);
         color: #2e3440;
         line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
       /* Nav */
       .navbar { border-bottom: 1px solid rgba(255,255,255,0.08); }
-      .navbar-brand { font-weight: 700; font-size: 1.25rem; letter-spacing: 0.5px; }
+      .navbar-brand {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 1.4rem;
+        letter-spacing: 0.5px;
+      }
 
       /* Hero */
       .hero-section {
@@ -31,15 +45,19 @@
         padding: 4.5rem 1rem 3.5rem;
       }
       .hero-section h1 {
-        font-size: 3rem;
-        font-weight: 800;
-        letter-spacing: -0.5px;
+        font-family: var(--font-display);
+        font-size: clamp(2.6rem, 5vw, 3.6rem);
+        font-weight: 700;
+        letter-spacing: -0.025em;
+        font-variation-settings: "opsz" 144;
+        margin-bottom: 0.6rem;
       }
       .hero-section h2 {
         font-size: 1.2rem;
         font-weight: 400;
         color: #a0aab4;
         max-width: 540px;
+        line-height: 1.55;
       }
       .hero-section img {
         max-height: 180px;
@@ -55,10 +73,10 @@
         background: var(--foks-accent);
         color: #fff;
         font-weight: 600;
-        font-size: 0.75rem;
-        letter-spacing: 0.5px;
+        font-size: 0.72rem;
+        letter-spacing: 0.6px;
         text-transform: uppercase;
-        padding: 0.15rem 0.55rem;
+        padding: 0.2rem 0.6rem;
         border-radius: 999px;
         margin-right: 0.5rem;
         vertical-align: middle;
@@ -76,13 +94,17 @@
       .section { padding: 3.5rem 0; }
       .section-alt { background: var(--foks-alt-bg); }
       .section h2 {
-        font-size: 1.65rem;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: clamp(1.7rem, 2.6vw, 2rem);
+        font-weight: 600;
+        letter-spacing: -0.015em;
         margin-bottom: 1.75rem;
       }
       .section h3 {
-        font-size: 1.15rem;
+        font-family: var(--font-display);
+        font-size: 1.25rem;
         font-weight: 600;
+        letter-spacing: -0.01em;
         margin-bottom: 0.6rem;
       }
       .section p { color: #444c56; }
@@ -106,8 +128,9 @@
       .code-card pre {
         margin: 0;
         padding: 1rem 1.25rem;
-        font-size: 0.85rem;
-        line-height: 1.6;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        line-height: 1.65;
         color: #c8ccd4;
         white-space: pre-wrap;
         word-break: break-word;
@@ -134,8 +157,10 @@
       /* Accordions */
       .accordion-item { border-color: var(--foks-border); }
       .accordion-button {
+        font-family: var(--font-display);
         font-weight: 600;
-        font-size: 1.1rem;
+        font-size: 1.15rem;
+        letter-spacing: -0.005em;
         padding: 1rem 1.25rem;
       }
       .accordion-button:not(.collapsed) {
@@ -148,13 +173,19 @@
 
       /* Small utility sections */
       .compact-section { padding: 2.5rem 0; }
-      .compact-section h2 { font-size: 1.4rem; margin-bottom: 1rem; }
+      .compact-section h2 {
+        font-family: var(--font-display);
+        font-size: 1.5rem;
+        font-weight: 600;
+        margin-bottom: 1rem;
+      }
 
       /* CTA buttons */
       .btn-foks {
         background: var(--foks-accent);
         border-color: var(--foks-accent);
         color: #fff;
+        font-weight: 500;
       }
       .btn-foks:hover {
         background: var(--foks-accent-hover);
@@ -172,7 +203,6 @@
 
       /* Responsiveness */
       @media (max-width: 767px) {
-        .hero-section h1 { font-size: 2.2rem; }
         .hero-section { padding: 3rem 1rem 2.5rem; }
         .section { padding: 2.5rem 0; }
         .feature-row img { max-height: 160px; margin-bottom: 1rem; }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>FOKS - Federated Open Key Service</title>
     <link href="/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700;9..144,800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
       :root {
         --foks-dark: #1b1f2e;
@@ -13,16 +16,27 @@
         --foks-muted: #6c7a89;
         --foks-alt-bg: #f5f7fa;
         --foks-border: #e0e4ea;
+
+        --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+        --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
       }
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-family: var(--font-body);
         color: #2e3440;
         line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
       /* Nav */
       .navbar { border-bottom: 1px solid rgba(255,255,255,0.08); }
-      .navbar-brand { font-weight: 700; font-size: 1.25rem; letter-spacing: 0.5px; }
+      .navbar-brand {
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: 1.4rem;
+        letter-spacing: 0.5px;
+      }
 
       /* Hero */
       .hero-section {
@@ -31,15 +45,19 @@
         padding: 4.5rem 1rem 3.5rem;
       }
       .hero-section h1 {
-        font-size: 3rem;
-        font-weight: 800;
-        letter-spacing: -0.5px;
+        font-family: var(--font-display);
+        font-size: clamp(2.6rem, 5vw, 3.6rem);
+        font-weight: 700;
+        letter-spacing: -0.025em;
+        font-variation-settings: "opsz" 144;
+        margin-bottom: 0.6rem;
       }
       .hero-section h2 {
         font-size: 1.2rem;
         font-weight: 400;
         color: #a0aab4;
         max-width: 540px;
+        line-height: 1.55;
       }
       .hero-section img {
         max-height: 180px;
@@ -55,10 +73,10 @@
         background: var(--foks-accent);
         color: #fff;
         font-weight: 600;
-        font-size: 0.75rem;
-        letter-spacing: 0.5px;
+        font-size: 0.72rem;
+        letter-spacing: 0.6px;
         text-transform: uppercase;
-        padding: 0.15rem 0.55rem;
+        padding: 0.2rem 0.6rem;
         border-radius: 999px;
         margin-right: 0.5rem;
         vertical-align: middle;
@@ -76,13 +94,17 @@
       .section { padding: 3.5rem 0; }
       .section-alt { background: var(--foks-alt-bg); }
       .section h2 {
-        font-size: 1.65rem;
-        font-weight: 700;
+        font-family: var(--font-display);
+        font-size: clamp(1.7rem, 2.6vw, 2rem);
+        font-weight: 600;
+        letter-spacing: -0.015em;
         margin-bottom: 1.75rem;
       }
       .section h3 {
-        font-size: 1.15rem;
+        font-family: var(--font-display);
+        font-size: 1.25rem;
         font-weight: 600;
+        letter-spacing: -0.01em;
         margin-bottom: 0.6rem;
       }
       .section p { color: #444c56; }
@@ -106,8 +128,9 @@
       .code-card pre {
         margin: 0;
         padding: 1rem 1.25rem;
-        font-size: 0.85rem;
-        line-height: 1.6;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        line-height: 1.65;
         color: #c8ccd4;
         white-space: pre-wrap;
         word-break: break-word;
@@ -134,8 +157,10 @@
       /* Accordions */
       .accordion-item { border-color: var(--foks-border); }
       .accordion-button {
+        font-family: var(--font-display);
         font-weight: 600;
-        font-size: 1.1rem;
+        font-size: 1.15rem;
+        letter-spacing: -0.005em;
         padding: 1rem 1.25rem;
       }
       .accordion-button:not(.collapsed) {
@@ -148,13 +173,19 @@
 
       /* Small utility sections */
       .compact-section { padding: 2.5rem 0; }
-      .compact-section h2 { font-size: 1.4rem; margin-bottom: 1rem; }
+      .compact-section h2 {
+        font-family: var(--font-display);
+        font-size: 1.5rem;
+        font-weight: 600;
+        margin-bottom: 1rem;
+      }
 
       /* CTA buttons */
       .btn-foks {
         background: var(--foks-accent);
         border-color: var(--foks-accent);
         color: #fff;
+        font-weight: 500;
       }
       .btn-foks:hover {
         background: var(--foks-accent-hover);
@@ -172,7 +203,6 @@
 
       /* Responsiveness */
       @media (max-width: 767px) {
-        .hero-section h1 { font-size: 2.2rem; }
         .hero-section { padding: 3rem 1rem 2.5rem; }
         .section { padding: 2.5rem 0; }
         .feature-row img { max-height: 160px; margin-bottom: 1rem; }


### PR DESCRIPTION
## Summary
- Add Fraunces (variable serif, optical sizing) for display headings and JetBrains Mono for code blocks, both via Google Fonts with preconnect.
- Applied to: hero h1, all section h2/h3 titles, accordion buttons, navbar brand, compact-section titles. Code cards now render in JetBrains Mono.
- Body text stays on the system sans stack for fast first paint.

No structural or copy changes — only typographic refinement of the existing layout.

## Test plan
- [ ] Visit `/` and confirm hero "FOKS" title renders in Fraunces
- [ ] Confirm code blocks (Git, KV, team, key, agent examples) render in JetBrains Mono
- [ ] Confirm accordions (How It Works, Guiding Principles) and section titles use Fraunces
- [ ] Verify mobile responsiveness — h1 should clamp down cleanly
- [ ] Spot-check that fonts load (no FOUC longer than ~100ms on a fast connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)